### PR TITLE
Code fence

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,8 +142,18 @@ fn main() {
         println!("{}\n", header);
     }
 
+    let mut in_code_fence = false;
+
     content
         .lines()
+        .filter(|line| {
+            if line.starts_with("```") {
+                in_code_fence = !in_code_fence;
+                false
+            } else {
+                !in_code_fence
+            }
+        })
         .map(Heading::from_str)
         .filter_map(Result::ok)
         .filter_map(|h| h.format(&config))

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,16 +142,24 @@ fn main() {
         println!("{}\n", header);
     }
 
-    let mut in_code_fence = false;
+    let mut code_fence = Fence::None;
 
     content
         .lines()
-        .filter(|line| {
-            if line.starts_with("```") {
-                in_code_fence = !in_code_fence;
+        .filter(|line| match code_fence {
+            Fence::None => {
+                if line.starts_with("```") || line.starts_with("~~~") {
+                    code_fence = Fence::Open(&line[..3]);
+                    false
+                } else {
+                    true
+                }
+            }
+            Fence::Open(tag) => {
+                if line.starts_with(tag) {
+                    code_fence = Fence::None;
+                }
                 false
-            } else {
-                !in_code_fence
             }
         })
         .map(Heading::from_str)
@@ -160,4 +168,9 @@ fn main() {
         .for_each(|l| {
             println!("{}", l);
         });
+}
+
+enum Fence<'e> {
+    Open(&'e str),
+    None,
 }


### PR DESCRIPTION
Hi, cool project! I am using [code fences](https://spec.commonmark.org/0.12/#code-fence) in my documentation and any lines beginning with`#` are showing up in the ToC. Here is a quick hack to ignore them.  Thanks for writing this crate!