### PR TITLE
Fix: common fix for all issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,18 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 fn slugify(text: &str) -> String {
-    percent_encode(text.replace(" ", "-").to_lowercase().as_bytes(), CONTROLS).to_string()
+    percent_encode(
+        text
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == ' ')
+            .map(|c| match c {
+                ' ' => '-',
+                _   => c.to_ascii_lowercase()
+            })
+            .collect::<String>()
+            .as_bytes(),
+        CONTROLS
+    ).to_string()
 }
 
 pub struct Heading {

--- a/tests/output
+++ b/tests/output
@@ -4,20 +4,20 @@ Philosophy, 2
 Inline HTML, 2
 Automatic Escaping for Special Characters, 2
 Block Elements, 1
-Paragraphs and Line Breaks, 2
+Paragraphs and Line Breaks `<br />`, 2
 Headers, 2
 Blockquotes, 2
-Lists, 2
+Lists, unordered and ordered, 2
 Code Blocks, 2
 Horizontal Rules, 2
 Span Elements, 1
-Links, 2
+Links (Anchors), 2
 Emphasis, 2
 Code, 2
 Images, 2
 Miscellaneous, 1
-Automatic Links, 2
-Backslash Escapes, 2
+1. Automatic Links, 2
+2. Backslash Escapes, 2
 한글 테스트, 1
 - [Test Markdown Document](#test-markdown-document)
   - [Overview](#overview)
@@ -25,20 +25,20 @@ Backslash Escapes, 2
     - [Inline HTML](#inline-html)
     - [Automatic Escaping for Special Characters](#automatic-escaping-for-special-characters)
   - [Block Elements](#block-elements)
-    - [Paragraphs and Line Breaks](#paragraphs-and-line-breaks)
+    - [Paragraphs and Line Breaks `<br />`](#paragraphs-and-line-breaks-br-)
     - [Headers](#headers)
     - [Blockquotes](#blockquotes)
-    - [Lists](#lists)
+    - [Lists, unordered and ordered](#lists-unordered-and-ordered)
     - [Code Blocks](#code-blocks)
     - [Horizontal Rules](#horizontal-rules)
   - [Span Elements](#span-elements)
-    - [Links](#links)
+    - [Links (Anchors)](#links-anchors)
     - [Emphasis](#emphasis)
     - [Code](#code)
     - [Images](#images)
   - [Miscellaneous](#miscellaneous)
-    - [Automatic Links](#automatic-links)
-    - [Backslash Escapes](#backslash-escapes)
+    - [1. Automatic Links](#1-automatic-links)
+    - [2. Backslash Escapes](#2-backslash-escapes)
   - [한글 테스트](#%ED%95%9C%EA%B8%80-%ED%85%8C%EC%8A%A4%ED%8A%B8)
 1. Overview
 1. Block Elements

--- a/tests/test.md
+++ b/tests/test.md
@@ -145,7 +145,7 @@ and `&` in your example code needs to be escaped.)
 ## Block Elements
 
 
-### Paragraphs and Line Breaks
+### Paragraphs and Line Breaks `<br />`
 
 A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
@@ -258,7 +258,7 @@ example, with BBEdit, you can make a selection and choose Increase
 Quote Level from the Text menu.
 
 
-### Lists
+### Lists, unordered and ordered
 
 Markdown supports ordered (numbered) and unordered (bulleted) lists.
 
@@ -505,7 +505,7 @@ following lines will produce a horizontal rule:
 
 ## Span Elements
 
-### Links
+### Links (Anchors)
 
 Markdown supports two style of links: *inline* and *reference*.
 
@@ -801,7 +801,7 @@ use regular HTML `<img>` tags.
 
 ## Miscellaneous
 
-### Automatic Links
+### 1. Automatic Links
 
 Markdown supports a shortcut style for creating "automatic" links for URLs and email addresses: simply surround the URL or email address with angle brackets. What this means is that if you want to show the actual text of a URL or email address, and also have it be a clickable link, you can do this:
 
@@ -834,7 +834,7 @@ will probably eventually start receiving spam.)
 
 
 
-### Backslash Escapes
+### 2. Backslash Escapes
 
 Markdown allows you to use backslash escapes to generate literal
 characters which would otherwise have special meaning in Markdown's


### PR DESCRIPTION
This PR should be a fix for all issues #7, #8, #9, and #10. 

My understand from this is that each markdown compiler has a different way of compiling these links and it is not feasible to try to accommodate every single style of generating the links for the headings. I am not sure if this is mentioned in the README, but I guess it is a good disclaimer. The following works for GitHub but it maybe different for a variety of markdown compilers.