### PR TITLE
Need to preserve `-` in original string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ fn slugify(text: &str) -> String {
     percent_encode(
         text
             .chars()
-            .filter(|c| c.is_alphanumeric() || *c == ' ')
+            .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-')
             .map(|c| match c {
                 ' ' => '-',
                 _   => c.to_ascii_lowercase()


### PR DESCRIPTION
This matches what github does.